### PR TITLE
Implement richer enemy behaviors and modifier effects

### DIFF
--- a/Slingpunk/objects/obj_Enemy/Create_0.gml
+++ b/Slingpunk/objects/obj_Enemy/Create_0.gml
@@ -13,6 +13,19 @@ enemy_is_boss = false;
 velocity_x = 0;
 velocity_y = 0;
 base_speed = enemy_speed;
+zigzag_phase = random(360);
+zigzag_speed = 0;
+zigzag_amplitude = 0;
+
+// Behavioural state
+type_configured = false;
+split_children_count = 0;
+split_spawned = false;
+magnet_range = 0;
+magnet_strength = 0;
+shield_arc = 0;
+shield_facing = 270;
+shield_spin = 0;
 
 // Status effects
 slow_timer = 0;

--- a/Slingpunk/objects/obj_Enemy/Draw_0.gml
+++ b/Slingpunk/objects/obj_Enemy/Draw_0.gml
@@ -43,6 +43,11 @@ if (enemy_shield > 0) {
     draw_set_alpha(shield_alpha);
     draw_set_color(c_aqua);
     draw_circle(x, y, radius + 16, true);
+
+    if (shield_arc > 0) {
+        draw_set_alpha(shield_alpha + 0.1);
+        draw_circle_arc(x, y, radius + 20, shield_facing - shield_arc * 0.5, shield_facing + shield_arc * 0.5, 6);
+    }
 }
 
 // Slow effect
@@ -51,6 +56,13 @@ if (slow_timer > 0) {
     draw_set_alpha(0.2 + slow_ratio * 0.45);
     draw_set_color(c_blue);
     draw_circle(x, y, radius + 20, true);
+}
+
+// Magnetron field hint
+if (enemy_type == EnemyKind.MAGNETRON && magnet_range > 0) {
+    draw_set_alpha(0.05);
+    draw_set_color(c_lime);
+    draw_circle(x, y, magnet_range, true);
 }
 
 draw_set_alpha(1);

--- a/Slingpunk/objects/obj_Enemy/Step_0.gml
+++ b/Slingpunk/objects/obj_Enemy/Step_0.gml
@@ -1,33 +1,100 @@
 // Enemy Step Event
 if (!enemy_alive) exit;
 
-elapsed_time += 1/60; // Assuming 60 FPS
+var dt = 1/60;
+elapsed_time += dt;
 
-// Update behavior (virtual function - override in child objects)
-enemy_behavior();
+if (!type_configured) {
+    enemy_apply_type_profile(id);
+}
+
+var apply_damping = true;
+
+switch (enemy_type) {
+    case EnemyKind.GLOOB_ZIGZAG:
+        zigzag_phase += zigzag_speed * dt;
+        velocity_y = base_speed;
+        velocity_x = dsin(zigzag_phase) * zigzag_amplitude;
+        apply_damping = false;
+        break;
+
+    case EnemyKind.SPLITTER_GLOOB:
+        zigzag_phase += zigzag_speed * dt;
+        velocity_y = base_speed;
+        velocity_x = dsin(zigzag_phase) * zigzag_amplitude;
+        apply_damping = false;
+        break;
+
+    case EnemyKind.SPLITTERLING:
+        zigzag_phase += zigzag_speed * dt;
+        velocity_y = base_speed;
+        velocity_x = dsin(zigzag_phase) * zigzag_amplitude;
+        apply_damping = false;
+        break;
+
+    case EnemyKind.SHIELDY_GLOOB:
+        velocity_y = base_speed;
+        var focus_orb = instance_nearest(x, y, obj_Orb);
+        if (instance_exists(focus_orb) && focus_orb.orb_alive) {
+            var desired_angle = point_direction(x, y, focus_orb.x, focus_orb.y);
+            shield_facing = lerp_value(shield_facing, desired_angle, 0.18);
+        } else {
+            shield_facing = lerp_value(shield_facing, 270, 0.12);
+        }
+        break;
+
+    case EnemyKind.MAGNETRON:
+        zigzag_phase += zigzag_speed * dt;
+        velocity_y = base_speed;
+        velocity_x = dsin(zigzag_phase) * zigzag_amplitude;
+        apply_damping = false;
+
+        if (magnet_range > 0 && magnet_strength > 0) {
+            var range_sq = magnet_range * magnet_range;
+            with (obj_Orb) {
+                if (!orb_alive) continue;
+                var dx = other.x - x;
+                var dy = other.y - y;
+                var dist_sq = dx * dx + dy * dy;
+                if (dist_sq <= range_sq) {
+                    var dist = max(16, sqrt(dist_sq));
+                    var pull = other.magnet_strength / max(80, dist_sq);
+                    var pull_step = min(pull, other.magnet_strength * 0.02);
+                    velocity_x += dx / dist * pull_step;
+                    velocity_y += dy / dist * pull_step;
+                }
+            }
+        }
+        break;
+
+    default:
+        enemy_behavior();
+}
 
 // Handle knockback
 if (knockback > 0) {
     velocity_y -= knockback;
-    knockback = max(0, knockback - (1/60) * 240);
+    knockback = max(0, knockback - dt * 240);
 }
 
 // Handle slow effect
 if (slow_timer > 0) {
     velocity_x *= slow_factor;
     velocity_y *= slow_factor;
-    slow_timer = max(0, slow_timer - 1/60);
+    slow_timer = max(0, slow_timer - dt);
     if (slow_timer == 0) {
         slow_factor = 1;
     }
 }
 
 // Apply movement
-x += velocity_x * (1/60);
-y += velocity_y * (1/60);
+x += velocity_x * dt;
+y += velocity_y * dt;
 
-// Damp horizontal velocity
-velocity_x *= 1 - min(0.12, (1/60) * 2);
+// Damp horizontal velocity for non-oscillating enemies
+if (apply_damping) {
+    velocity_x *= 1 - min(0.12, dt * 2);
+}
 
 // Check if enemy breached bottom
 if (y - enemy_radius > room_height - BOTTOM_SAFE_ZONE) {
@@ -36,5 +103,24 @@ if (y - enemy_radius > room_height - BOTTOM_SAFE_ZONE) {
     with (obj_Game) {
         event_user(1); // User Event 1 for enemy breach
     }
+    instance_destroy();
+    exit;
+}
+
+// Handle death
+if (enemy_hp <= 0) {
+    enemy_alive = false;
+    spawn_particles(x, y, accent_color, 16, 260, enemy_radius + 12);
+    spawn_impact_wave(x, y, enemy_radius + 28, 0.35, accent_color);
+
+    if (enemy_type == EnemyKind.SPLITTER_GLOOB && !split_spawned) {
+        split_spawned = true;
+        enemy_spawn_splitlings(id);
+    }
+
+    with (obj_Game) {
+        event_user(0); // Enemy killed
+    }
+
     instance_destroy();
 }

--- a/Slingpunk/objects/obj_Game/Step_0.gml
+++ b/Slingpunk/objects/obj_Game/Step_0.gml
@@ -7,6 +7,11 @@ launch_cooldown = 0; //max(0, launch_cooldown - 1/60);
 combo_timer += 1/60;
 wave_intro_delay = max(0, wave_intro_delay - 1/60);
 
+// Update modifier timers
+if (!is_undefined(modifiers.chainLightning)) {
+    modifiers.chainLightning.cooldown = max(0, modifiers.chainLightning.cooldown - 1/60);
+}
+
 // Handle input
 handle_input();
 

--- a/Slingpunk/scripts/GameUtils/GameUtils.gml
+++ b/Slingpunk/scripts/GameUtils/GameUtils.gml
@@ -132,3 +132,22 @@ function array_remove_value(_array, _value) {
     }
     return false;
 }
+
+function array_shuffle_ext(_array) {
+    var _count = array_length(_array);
+    if (_count <= 1) return;
+
+    for (var _i = _count - 1; _i > 0; _i--) {
+        var _swap_index = irandom(_i);
+        if (_swap_index == _i) continue;
+
+        var _temp = _array[_i];
+        _array[_i] = _array[_swap_index];
+        _array[_swap_index] = _temp;
+    }
+}
+
+function struct_exists(_struct, _name) {
+    if (!is_struct(_struct)) return false;
+    return variable_struct_exists(_struct, _name);
+}

--- a/Slingpunk/scripts/OrbFunctions/OrbFunctions.gml
+++ b/Slingpunk/scripts/OrbFunctions/OrbFunctions.gml
@@ -2,26 +2,163 @@
 function orb_wall_bounce() {
     orb_bounce_count += 1;
     // Apply wall damage bonus if available
-    if (instance_exists(obj_Game)) {
-        var wall_bonus = obj_Game.modifiers.wallHitDamageBonusPercent;
+    var controller = instance_find(obj_Game, 0);
+    if (controller != noone) {
+        var wall_bonus = controller.modifiers.wallHitDamageBonusPercent;
         if (wall_bonus > 0) {
             orb_pending_wall_damage_bonus = wall_bonus;
         }
 
-        // Create particles at impact point
-        spawn_particles(x, y, c_aqua, 5, 40, 120);
+        with (controller) {
+            spawn_particles(other.x, other.y, c_aqua, 5, 40, 120);
+        }
     }
 }
 
 function orb_hit_enemy(_enemy) {
+    if (!instance_exists(_enemy) || !_enemy.enemy_alive) return;
+
+    var controller = instance_find(obj_Game, 0);
+    var modifiers_struct = undefined;
+    var difficulty_struct = undefined;
+    var combo_value = 0;
+
+    if (controller != noone) {
+        modifiers_struct = controller.modifiers;
+        difficulty_struct = controller.difficulty;
+        combo_value = controller.combo_heat;
+    }
+
     // Calculate damage
-    var damage = orb_damage;
-    if (instance_exists(obj_Game)) {
-        with obj_Game damage = compute_orb_damage(other.id, _enemy);
+    var damage = compute_orb_damage(id, _enemy, modifiers_struct, combo_value, difficulty_struct);
+
+    // Shield handling for Shieldy enemies
+    if (_enemy.enemy_shield > 0) {
+        var shield_arc = 0;
+        var shield_dir = 270;
+        if (variable_instance_exists(_enemy, "shield_arc")) shield_arc = _enemy.shield_arc;
+        if (variable_instance_exists(_enemy, "shield_facing")) shield_dir = _enemy.shield_facing;
+
+        if (shield_arc > 0) {
+            var approach_angle = point_direction(_enemy.x, _enemy.y, x, y);
+            var shield_diff = angle_difference(shield_dir, approach_angle);
+            if (abs(shield_diff) <= shield_arc * 0.5) {
+                _enemy.enemy_shield = max(0, _enemy.enemy_shield - max(1, damage));
+
+                if (controller != noone) {
+                    var shield_fx_x = _enemy.x;
+                    var shield_fx_y = _enemy.y;
+                    var shield_fx_radius = _enemy.enemy_radius + 24;
+                    var shield_wave_radius = _enemy.enemy_radius + 30;
+                    with (controller) {
+                        spawn_particles(shield_fx_x, shield_fx_y, c_aqua, 12, 280, shield_fx_radius);
+                        spawn_impact_wave(shield_fx_x, shield_fx_y, shield_wave_radius, 0.22, c_aqua);
+                    }
+                }
+
+                orb_bounce_count += 1;
+                var bounce_speed = max(220, vector2_length(Vector2(velocity_x, velocity_y)) * 0.6);
+                var bounce_dir = point_direction(_enemy.x, _enemy.y, x, y) + 180;
+                velocity_x = lengthdir_x(bounce_speed, bounce_dir);
+                velocity_y = lengthdir_y(bounce_speed, bounce_dir);
+
+                if (_enemy.enemy_shield <= 0 && controller != noone) {
+                    var break_x = _enemy.x;
+                    var break_y = _enemy.y;
+                    with (controller) {
+                        spawn_floating_text("Shield Break!", break_x, break_y, c_aqua);
+                    }
+                }
+
+                return;
+            }
+        }
     }
 
     // Deal damage to enemy
-    _enemy.enemy_hp -= (damage);
+    _enemy.enemy_hp -= damage;
+
+    if (!is_undefined(modifiers_struct)) {
+        // Apply slow effect
+        if (!is_undefined(modifiers_struct.slowEffect)) {
+            _enemy.slow_timer = max(_enemy.slow_timer, modifiers_struct.slowEffect.duration);
+            _enemy.slow_factor = min(_enemy.slow_factor, modifiers_struct.slowEffect.factor);
+        }
+
+        // Apply knockback
+        if (modifiers_struct.knockbackForce > 0) {
+            _enemy.knockback = max(_enemy.knockback, modifiers_struct.knockbackForce);
+        }
+
+        // Explosion effect
+        if (!is_undefined(modifiers_struct.explosion)) {
+            if (controller != noone) {
+                var explosion_x = _enemy.x;
+                var explosion_y = _enemy.y;
+                var explosion_radius = modifiers_struct.explosion.radius;
+                with (controller) {
+                    spawn_impact_wave(explosion_x, explosion_y, explosion_radius, 0.4, c_orange);
+                    spawn_particles(explosion_x, explosion_y, c_orange, 18, 360, explosion_radius);
+                }
+            }
+
+            var explosion_radius = modifiers_struct.explosion.radius;
+            var explosion_damage = modifiers_struct.explosion.damage;
+            var source_enemy = _enemy;
+
+            with (obj_Enemy) {
+                if (!enemy_alive) continue;
+                if (id == source_enemy.id) continue;
+
+                var dist = point_distance(x, y, source_enemy.x, source_enemy.y);
+                if (dist <= explosion_radius) {
+                    enemy_hp -= explosion_damage;
+                }
+            }
+        }
+
+        // Chain lightning effect
+        if (!is_undefined(modifiers_struct.chainLightning) && instance_number(obj_Enemy) > 1) {
+            var lightning = modifiers_struct.chainLightning;
+            if (lightning.cooldown <= 0) {
+                var lightning_range = lightning.range;
+                var range_sq = lightning_range * lightning_range;
+                var lightning_damage = lightning.damage;
+                var origin_enemy = _enemy;
+
+                with (obj_Enemy) {
+                    if (!enemy_alive) continue;
+                    if (id == origin_enemy.id) continue;
+
+                    var dx = x - origin_enemy.x;
+                    var dy = y - origin_enemy.y;
+                    if (dx * dx + dy * dy <= range_sq) {
+                        enemy_hp -= lightning_damage;
+                        if (controller != noone) {
+                            var fx_x = x;
+                            var fx_y = y;
+                            with (controller) {
+                                spawn_particles(fx_x, fx_y, c_aqua, 10, 280, lightning_range * 0.35);
+                            }
+                        }
+                    }
+                }
+
+                lightning.cooldown = lightning.interval;
+            }
+        }
+    }
+
+    if (controller != noone) {
+        var impact_x = _enemy.x;
+        var impact_y = _enemy.y;
+        var impact_radius = _enemy.enemy_radius + 12;
+        var impact_wave_radius = _enemy.enemy_radius + 20;
+        with (controller) {
+            spawn_particles(impact_x, impact_y, orb_color, 10, 320, impact_radius);
+            spawn_impact_wave(impact_x, impact_y, impact_wave_radius, 0.3, orb_color);
+        }
+    }
 
     // Handle split on impact
     if (orb_split_on_impact) {


### PR DESCRIPTION
## Summary
- route particle and impact wave spawning through the controller and extend damage math to respect run modifiers
- add modifier utilities for array shuffling and struct checks used by the drafting systems
- expand orb-on-enemy contact to honor shields, knockback, slow, explosions, and chain lightning visuals
- configure per-enemy behaviors including zigzag, shield tracking, magnetron pulls, splitter spawns, and updated death handling with feedback cues
- draw directional shield arcs and magnet fields for better readability

## Testing
- not run (GameMaker project)


------
https://chatgpt.com/codex/tasks/task_e_68d0d7fdf380832daa84ecd568511c61