### PR TITLE
Overhaul wave progression and diversify enemy behaviors

### DIFF
--- a/Slingpunk/objects/obj_Enemy/Create_0.gml
+++ b/Slingpunk/objects/obj_Enemy/Create_0.gml
@@ -40,3 +40,13 @@ secondary_color = c_dkgray;
 core_color = c_white;
 spikes_count = 6;
 sides_count = 6;
+
+// Ability timers
+spore_timer = 0;
+spore_interval = 0;
+warp_timer = 0;
+warp_interval = 0;
+warp_flash_timer = 0;
+support_timer = 0;
+support_interval = 0;
+support_flash = 0;

--- a/Slingpunk/objects/obj_Enemy/Draw_0.gml
+++ b/Slingpunk/objects/obj_Enemy/Draw_0.gml
@@ -65,5 +65,21 @@ if (enemy_type == EnemyKind.MAGNETRON && magnet_range > 0) {
     draw_circle(x, y, magnet_range, true);
 }
 
+// Warp flash indicator
+if (enemy_type == EnemyKind.WARP_STALKER && warp_flash_timer > 0) {
+    var warp_ratio = warp_flash_timer / 0.3;
+    draw_set_alpha(0.18 + warp_ratio * 0.32);
+    draw_set_color(accent_color);
+    draw_circle(x, y, radius + 26 + warp_ratio * 18, true);
+}
+
+// Support pulse
+if (enemy_type == EnemyKind.AEGIS_SENTINEL && support_flash > 0) {
+    var support_ratio = support_flash / 0.35;
+    draw_set_alpha(0.15 + support_ratio * 0.4);
+    draw_set_color(accent_color);
+    draw_circle(x, y, radius + 30, true);
+}
+
 draw_set_alpha(1);
 draw_self();

--- a/Slingpunk/objects/obj_Enemy/Step_0.gml
+++ b/Slingpunk/objects/obj_Enemy/Step_0.gml
@@ -4,6 +4,9 @@ if (!enemy_alive) exit;
 var dt = 1/60;
 elapsed_time += dt;
 
+if (warp_flash_timer > 0) warp_flash_timer = max(0, warp_flash_timer - dt);
+if (support_flash > 0) support_flash = max(0, support_flash - dt);
+
 if (!type_configured) {
     enemy_apply_type_profile(id);
 }
@@ -63,6 +66,71 @@ switch (enemy_type) {
                     velocity_x += dx / dist * pull_step;
                     velocity_y += dy / dist * pull_step;
                 }
+            }
+        }
+        break;
+
+    case EnemyKind.SPORE_PUFF:
+        zigzag_phase += zigzag_speed * dt;
+        velocity_y = base_speed * (0.85 + sin(elapsed_time * 1.6) * 0.08);
+        velocity_x = dsin(zigzag_phase) * zigzag_amplitude;
+        apply_damping = false;
+
+        if (spore_interval > 0) {
+            spore_timer -= dt;
+            if (spore_timer <= 0 && y < room_height - BOTTOM_SAFE_ZONE - 60) {
+                spore_timer = random_range_value(spore_interval * 0.6, spore_interval * 1.15);
+                if (instance_number(obj_Enemy) < 120) {
+                    var offset = random_range_value(-18, 18);
+                    var spore = instance_create_layer(x + offset, y + enemy_radius, "Instances", obj_Enemy);
+                    spore.enemy_type = EnemyKind.SPLITTERLING;
+                    spore.enemy_hp = 1;
+                    spore.enemy_max_hp = 1;
+                    spore.enemy_speed = BASE_ENEMY_SPEED * 1.15;
+                    spore.enemy_radius = 18;
+                    spore.base_speed = spore.enemy_speed;
+                    spore.type_configured = false;
+                    enemy_apply_type_profile(spore);
+                }
+                spawn_particles(x, y, accent_color, 6, 180, enemy_radius + 16);
+            }
+        }
+        break;
+
+    case EnemyKind.BULWARK_GLOOB:
+        velocity_y = base_speed;
+        shield_facing = (shield_facing + shield_spin * dt) mod 360;
+        enemy_shield = min(8, enemy_shield + dt * 0.9);
+        break;
+
+    case EnemyKind.WARP_STALKER:
+        velocity_y = base_speed;
+        warp_timer -= dt;
+        if (warp_timer <= 0 && y < room_height - BOTTOM_SAFE_ZONE - 40) {
+            warp_timer = random_range_value(max(0.8, warp_interval * 0.55), max(1.4, warp_interval));
+            warp_flash_timer = 0.3;
+            var new_lane = irandom_range(1, 6);
+            var target = lane_to_world(new_lane, room_width);
+            spawn_particles(x, y, accent_color, 10, 240, enemy_radius + 22);
+            x = target.x + random_range_value(-12, 12);
+            spawn_particles(x, y, accent_color, 12, 260, enemy_radius + 28);
+        }
+        break;
+
+    case EnemyKind.AEGIS_SENTINEL:
+        velocity_y = base_speed;
+        shield_facing = (shield_facing + 120 * dt) mod 360;
+        support_timer -= dt;
+        if (support_timer <= 0) {
+            support_timer = random_range_value(max(1.0, support_interval * 0.6), max(1.6, support_interval * 1.1));
+            var ally = instance_nearest(x, y, obj_Enemy);
+            if (instance_exists(ally) && ally.id != id && ally.enemy_alive && ally.enemy_type != EnemyKind.SPLITTERLING) {
+                ally.enemy_shield = max(ally.enemy_shield, ceil(3 + ally.enemy_max_hp * 0.1));
+                ally.shield_arc = max(ally.shield_arc, 160);
+                ally.enemy_hp = min(ally.enemy_max_hp, ally.enemy_hp + 2);
+                spawn_particles(ally.x, ally.y, accent_color, 8, 220, ally.enemy_radius + 26);
+                spawn_particles(x, y, accent_color, 6, 200, enemy_radius + 20);
+                support_flash = 0.35;
             }
         }
         break;

--- a/Slingpunk/objects/obj_Game/Create_0.gml
+++ b/Slingpunk/objects/obj_Game/Create_0.gml
@@ -44,6 +44,13 @@ modifiers = ModifierState();
 // Wave management
 wave_manager_active = false;
 wave_intro_delay = 0;
+wave_blueprints = [];
+wave_spawn_events = [];
+wave_spawn_index = 0;
+wave_elapsed = 0;
+wave_break_timer = 0;
+current_wave_state = undefined;
+wave_preview_text = "";
 
 // Screen effects
 screen_shake_x = 0;
@@ -64,6 +71,9 @@ difficulty = DifficultyDefinition("normal", "Normal", "Balanced challenge",
 
 // Initialize background
 init_background();
+
+// Setup wave data
+init_wave_manager();
 
 // Start the game
 start_game();

--- a/Slingpunk/objects/obj_Game/Step_0.gml
+++ b/Slingpunk/objects/obj_Game/Step_0.gml
@@ -43,9 +43,9 @@ update_floating_text();
 // Update impact waves
 update_impact_waves();
 
-// Simple wave management (spawn enemies periodically)
-if (wave_manager_active && wave_intro_delay <= 0) {
-    simple_wave_spawning();
+// Wave management
+if (wave_manager_active) {
+    update_wave_manager();
 }
 
 // Check for game over

--- a/Slingpunk/scripts/GameTypes/GameTypes.gml
+++ b/Slingpunk/scripts/GameTypes/GameTypes.gml
@@ -124,13 +124,16 @@ function EnemyWaveScaling(_level, _hpMultiplier, _hpBonus, _speedMultiplier, _co
 }
 
 // Wave enemy config structure
-function WaveEnemyConfig(_type, _hp, _lane, _count, _cadence) {
+function WaveEnemyConfig(_type, _hp, _lane, _count, _cadence, _speedScale = 1, _eliteChance = 0, _spawnOffset = 0) {
     return {
         type: _type,
         hp: _hp,
         lane: _lane,
         count: _count,
-        cadence: _cadence
+        cadence: _cadence,
+        speedScale: _speedScale,
+        eliteChance: _eliteChance,
+        spawnOffset: _spawnOffset
     };
 }
 


### PR DESCRIPTION
## Summary
- replace the timer-based spawner with a wave manager that schedules handcrafted and dynamic wave blueprints, handles scaling, and shows the next wave preview on the HUD
- reset and UI logic hook into the new manager so waves scale over time, reward the player, and provide brief breaks between encounters
- add new enemy archetypes (Spore Puff, Bulwark Gloob, Warp Stalker, Aegis Sentinel) with unique movement, support, and visual effects

## Testing
- not run (GameMaker project)


------
https://chatgpt.com/codex/tasks/task_e_68d3ad4b74e0832d9174191fd6725ce8